### PR TITLE
Explicitly license the example code as BSD 2-clause

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,22 @@
+Copyright 2017-2023 Daniel Bevenius
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ### Learning OpenSSL
-The sole purpose of this project is to learn OpenSSL's libcryto library.
+The sole purpose of this project is to learn OpenSSL's libcrypto library.
 
+All included examples are licensed under the BSD 2-clause license, unless
+stated otherwise.
 
 ### Building
 


### PR DESCRIPTION
BSD 2-clause was picked as a license for the examples because of its flexibility, utility, and simplicity of terms.

This change is precipitated by an email discussion with the learning-openssl repo primary author (Daniel Benevius).

While here, fix a typo in the header for `README.md` :).